### PR TITLE
Ensure that the first digit of a randomly generated `BigInt` is non-zero

### DIFF
--- a/include/functions/random.hpp
+++ b/include/functions/random.hpp
@@ -34,7 +34,7 @@ BigInt big_random(size_t num_digits = 0) {
     big_rand.value = "";    // clear value to append digits
 
     // ensure first digit is non-zero
-    big_rand.value += std::to_string(rand_generator() % 8 + 1);
+    big_rand.value += std::to_string(rand_generator() % 9 + 1);
     while (big_rand.value.size() < num_digits)
         big_rand.value += std::to_string(rand_generator());
     if (big_rand.value.size() != num_digits)

--- a/include/functions/random.hpp
+++ b/include/functions/random.hpp
@@ -32,6 +32,9 @@ BigInt big_random(size_t num_digits = 0) {
 
     BigInt big_rand;
     big_rand.value = "";    // clear value to append digits
+
+    // ensure first digit is non-zero
+    big_rand.value += std::to_string(rand_generator() % 8 + 1);
     while (big_rand.value.size() < num_digits)
         big_rand.value += std::to_string(rand_generator());
     if (big_rand.value.size() != num_digits)


### PR DESCRIPTION
Generates the first digit of a random BigInt to be a value from one to nine, inclusive, guaranteeing there will be no leading zeros.

Closes #40.