### PR TITLE
Updated Single-Include Header Download and *nix Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ and more).
 On Linux and macOS, you can compile and run the tests using the command line.
 * To compile the tests, run **`make`**.
 * To build and run the tests, run **`make test`**.
-* To generate the single-header file from the headers in the 'include' folder, run **`make release`**
+* To generate the single-header file from the headers in the `include` folder, run **`make release`**
 
 ### Using an IDE that supports CMake
 

--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ and more).
 
 ### Using the command line
 
-On Linux and macOS, you can compile and run the tests using the command line.
+On Linux and macOS, you can compile and run the tests using the command line from the project's root directory.
 * To compile the tests, run **`make`**.
 * To build and run the tests, run **`make test`**.
-* To generate the single-header file from the headers in the `include` folder, run **`make release`**
+* To generate the single-header file, run **`make release`**. This will appear in the `release` folder.
 
 ### Using an IDE that supports CMake
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ and more).
 On Linux and macOS, you can compile and run the tests using the command line from the project's root directory.
 * To compile the tests, run **`make`**.
 * To build and run the tests, run **`make test`**.
-* To generate the single-header file, run **`make release`**. This will appear in the `release` folder.
+* To generate the single-include header file, run **`make release`**. The generated file will appear in the `release` folder.
 
 ### Using an IDE that supports CMake
 
@@ -262,4 +262,4 @@ This project is licensed under the terms of the [MIT license][license-link].
 [license-link]: https://github.com/faheel/BigInt/blob/master/LICENSE
 [out_of_range-exception]: http://en.cppreference.com/w/cpp/error/out_of_range
 [contributing-link]: https://github.com/faheel/BigInt/blob/master/.github/CONTRIBUTING.md
-[header-link]: https://github.com/faheel/BigInt/releases/download/v0.1.0-dev/BigInt.hpp
+[header-link]: https://github.com/faheel/BigInt/releases/download/v0.4.0-dev/BigInt.hpp

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ and more).
 On Linux and macOS, you can compile and run the tests using the command line.
 * To compile the tests, run **`make`**.
 * To build and run the tests, run **`make test`**.
-* To generate the single-header from the include/ folders, run **`make release`**
+* To generate the single-header file from the headers in the 'include' folder, run **`make release`**
 
 ### Using an IDE that supports CMake
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## Usage
 
-1. Download the [single-include header file][release-link] to a location under
+1. Download the [single-include header file][header-link] to a location under
     your include path. Then `#include` it in your code:
     ```c++
     #include "BigInt.hpp"   // the actual path may vary
@@ -225,6 +225,7 @@ and more).
 On Linux and macOS, you can compile and run the tests using the command line.
 * To compile the tests, run **`make`**.
 * To build and run the tests, run **`make test`**.
+* To generate the single-header from the include/ folders, run **`make release`**
 
 ### Using an IDE that supports CMake
 
@@ -261,3 +262,4 @@ This project is licensed under the terms of the [MIT license][license-link].
 [license-link]: https://github.com/faheel/BigInt/blob/master/LICENSE
 [out_of_range-exception]: http://en.cppreference.com/w/cpp/error/out_of_range
 [contributing-link]: https://github.com/faheel/BigInt/blob/master/.github/CONTRIBUTING.md
+[header-link]: https://github.com/faheel/BigInt/releases/download/v0.1.0-dev/BigInt.hpp


### PR DESCRIPTION
The single-include header file used to link to the release-link instead of the actual header file which was in the assets of the provided link. New users might get confused when they aren't taken directly to the header file or when it doesn't begin downloading when they click the link, which is what happens now. Also, if you're working on the code in the different header files, you won't have an up-to-date single-include header, so I've added the command to generate that release header as a third bullet point to the "Using the command line" section of the README.