### PR TITLE
bugfix for [functions][math][pow] and supply more test cases.

### DIFF
--- a/include/functions/math.hpp
+++ b/include/functions/math.hpp
@@ -45,7 +45,12 @@ BigInt pow(const BigInt& base, int exp) {
     if (exp < 0) {
         if (base == 0)
             throw std::logic_error("Cannot divide by zero");
-        return abs(base) == 1 ? base : 0;
+        if (base == 1 || exp % 2 == 0)
+            return 1;
+        else if (base == -1)
+            return exp % 2 == 0 ? 1 : -1;
+        else
+            return 0;
     }
     if (exp == 0) {
         if (base == 0)

--- a/test/functions/math.cpp
+++ b/test/functions/math.cpp
@@ -86,9 +86,11 @@ TEST_CASE("Base cases for pow()", "[functions][math][pow]") {
     REQUIRE(pow("1",  0) == 1);
     REQUIRE(pow("1",  1) == 1);
 
+    REQUIRE(pow("-1", -2) ==  1);
     REQUIRE(pow("-1", -1) == -1);
     REQUIRE(pow("-1",  0) ==  1);
     REQUIRE(pow("-1",  1) == -1);
+    REQUIRE(pow("-1",  2) ==  1);
 }
 
 TEST_CASE("pow() with BigInt base", "[functions][math][pow]") {


### PR DESCRIPTION
The old one will fail if base==-1 && exp is even, and the result should be 1 instead of -1.